### PR TITLE
changing the font-size management

### DIFF
--- a/app/assets/scss/_settings.scss
+++ b/app/assets/scss/_settings.scss
@@ -64,7 +64,7 @@ $font-base          : Arial, 'Helvetica Neue', Helvetica, sans-serif;
 $font-code          : 'Source Code Pro', Consolas, monospace;
 $font-title         : $font-base;
 
-$font-size-base     : 1rem;
+$font-size-base     : 1.6rem;
 // Don't touch this, it's for em convertion
 $em-base            : strip-units($font-size-base)*10;
 

--- a/app/assets/scss/_settings.scss
+++ b/app/assets/scss/_settings.scss
@@ -82,8 +82,8 @@ $font-size-S   : 1.6rem;
 $font-size-XS  : 1.4rem;
 $font-size-XXS : 1.2rem;
 
-$line-height-base  : 1.625em;
-$line-height-small : 1.25em;
+$line-height-base  : 1.625;
+$line-height-small : 1.25;
 
 //
 // 3 - Grid

--- a/app/assets/scss/_settings.scss
+++ b/app/assets/scss/_settings.scss
@@ -64,20 +64,23 @@ $font-base          : Arial, 'Helvetica Neue', Helvetica, sans-serif;
 $font-code          : 'Source Code Pro', Consolas, monospace;
 $font-title         : $font-base;
 
-$font-size-base     : 1em;
+$font-size-base     : 1rem;
+// Don't touch this, it's for em convertion
+$em-base            : strip-units($font-size-base)*10;
+
 $font-color-base    : $clr-0;
 
 $font-weight-bold : bold;
 $font-weight-base : 400;
 $font-weight-thin : 100;
 
-$font-size-XXL : em(40, $em-base);
-$font-size-XL  : em(28, $em-base);
-$font-size-L   : em(20, $em-base);
-$font-size-M   : em(18, $em-base);
-$font-size-S   : em(16, $em-base);
-$font-size-XS  : em(14, $em-base);
-$font-size-XXS  : em(12, $em-base);
+$font-size-XXL : 4rem;
+$font-size-XL  : 2.8rem;
+$font-size-L   : 2rem;
+$font-size-M   : 1.8rem;
+$font-size-S   : 1.6rem;
+$font-size-XS  : 1.4rem;
+$font-size-XXS : 1.2rem;
 
 $line-height-base  : 1.625em;
 $line-height-small : 1.25em;
@@ -86,16 +89,16 @@ $line-height-small : 1.25em;
 // 3 - Grid
 // ---------------------------------------
 
-$wrap-max-width : em(1000, $em-base);
-$wrap-min-width : em(320, $em-base);
-$gutter-width   : rem(20);
+$wrap-max-width : 100rem;
+$wrap-min-width : 320rem;
+$gutter-width   : 2rem;
 
 //
 // 4 - Radius
 // ---------------------------------------
 
-$radS : rem(3);
-$radL : rem(10);
+$radS : 0.3rem;
+$radL : 1rem;
 
 //
 // 5 - Forms
@@ -113,7 +116,7 @@ $form-font-size          : $font-size-base;
 // 6 - Spacing
 // ---------------------------------------
 
-$spacer   : rem(26);
+$spacer   : 2.6rem;
 $spacer-n : 0;
 $spacer-s : $spacer/2;
 $spacer-m : $spacer * 2;

--- a/app/assets/scss/base/_b-init.scss
+++ b/app/assets/scss/base/_b-init.scss
@@ -2,9 +2,13 @@
  * Base : Init
  * ======================================= */
 
+// 1 - Set the font-size to 10px, which is adapted to rem unit
+// 2  IE9-IE11 math fixing. See http://bit.ly/1g4X0bX
 html {
-  height: 100%;
   box-sizing: border-box;
+  height: 100%;
+  font-size: 62.5%; // 1
+  font-size: calc(1em * 0.625); // 2
 }
 
 *,

--- a/app/assets/scss/components/_list.scss
+++ b/app/assets/scss/components/_list.scss
@@ -13,7 +13,7 @@
     display: inline-block;
     vertical-align: middle;
     + li {
-      margin-left: rem(5);
+      margin-left: 5rem;
     }
   }
 }

--- a/app/assets/scss/components/_pod.scss
+++ b/app/assets/scss/components/_pod.scss
@@ -10,9 +10,9 @@
 }
 
 .pod-title {
-  margin-top: rem(26);
-  margin-bottom: rem(25);
-  padding-bottom: rem(6);
+  margin-top: $spacer;
+  margin-bottom: $spacer;
+  padding-bottom: 0.6rem;
   @include title;
   font-size: $font-size-XL;
   border-bottom: 4px solid;

--- a/app/assets/scss/components/button/_button.scss
+++ b/app/assets/scss/components/button/_button.scss
@@ -45,7 +45,7 @@
 
   + [class*=button] {
     @media (min-width: $mq-s-up) {
-      margin-left: rem(10);
+      margin-left: 1rem;
     }
   }
 

--- a/app/assets/scss/components/form/_form.scss
+++ b/app/assets/scss/components/form/_form.scss
@@ -35,7 +35,7 @@
   input[type="number"],
   textarea,
   select {
-    padding: rem(7) rem(10);
+    padding: 0.7rem 1rem;
     line-height: 1.5;
     width: 100%;
     border: 1px solid $form-border-color;

--- a/app/assets/scss/components/form/_formInputIcon.scss
+++ b/app/assets/scss/components/form/_formInputIcon.scss
@@ -9,17 +9,17 @@
 
 [class*=form-input--icon][class*=form-input--icon] {
   input {
-    padding-right: rem(40);
+    padding-right: 4rem;
   }
   [class*=icon-] {
     pointer-events: none;
     cursor: default;
     position: absolute;
     top: 50%;
-    right: rem(12);
+    right: 1.2rem;
     line-height: 1;
     text-align: center;
-    font-size: rem(20);
+    font-size: 2rem;
     color: $clr-0;
     transform: translateY(-50%);
   }
@@ -27,11 +27,11 @@
 
 .form-input--iconInverse.form-input--iconInverse {
   input {
-    padding-right: rem(10);
-    padding-left: rem(40);
+    padding-right: 1rem;
+    padding-left: 4rem;
   }
   [class*=icon-] {
     right: auto;
-    left: rem(12);
+    left: 1.2rem;
   }
 }

--- a/app/assets/scss/tools/_function.scss
+++ b/app/assets/scss/tools/_function.scss
@@ -1,5 +1,10 @@
+// Strip units
+@function strip-units($value) {
+  @return ($value / ($value * 0 + 1));
+}
+
 // Base font Size
-$em-base: 16px !default;
+$em-base: 16 !default;
 
 // PX to EM
 @function em($pxval, $base: $em-base) {
@@ -10,23 +15,6 @@ $em-base: 16px !default;
     $base: strip-units($base);
   }
   @return ($pxval / $base) * 1em;
-}
-
-// PX to REM
-@function rem($pxval) {
-  @if not unitless($pxval) {
-    $pxval: strip-units($pxval);
-  }
-  $base: $em-base;
-  @if not unitless($base) {
-    $base: strip-units($base);
-  }
-  @return ($pxval / $base) * 1rem;
-}
-
-// Strip units
-@function strip-units($value) {
-  @return ($value / ($value * 0 + 1));
 }
 
 // Mixes a color with black


### PR DESCRIPTION
L'idée avec cette branche :
1. Résoudre le problème de calcul de font-size quand on passe le texte en 14 sur le body.
2. Régler problème de calcul de font-size sous IE11[http://bit.ly/1g4X0bX](http://bit.ly/1g4X0bX)
3 Supprimer le helper de REM et travailler en rem à la place des px

Les modifications :
1. Ont passe le body en 10px
2. La font size général est passée par la variable `$font-size-base`
3. Suppression du helper rem()

Cas d'utilisation des différentes unités :
1. **REM** : unité de base. Par exemple `1.6rem` = `16px`
2. A utiliser seulement sur les éléments dépendant de la font-size afin d'éviter les effets de bords, et le média queries car les REM produisent des bugs sous Safari.
3. PX pour les bordures, les filets…
