### PR TITLE
fix(gulp): include `assets/img/*.svg`

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -57,7 +57,7 @@ module.exports = {
     files_src: [
       "!" + src + "/assets/img/sprite/**/*.svg",
       "!" + src + "/assets/img/sprite.svg",
-      src + "/assets/img/**/*.{jpg,png,gif, svg}",
+      src + "/assets/img/**/*.{jpg,png,gif,svg}",
     ],
     dist: assets_dist,
   },


### PR DESCRIPTION
SVG files in `./src/assets/img/` were ignored due to the space in the suffix list