### PR TITLE
chore(gulp): include `node_modules` in sass paths

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -20,7 +20,12 @@ gulp.task("styles", () => {
       })
     )
     .pipe(!options.production ? sourcemaps.init() : gutil.noop())
-    .pipe(sass({ precision: 10 }))
+    .pipe(
+      sass({ 
+        precision: 10, 
+        includePaths: ['node_modules/'], 
+      })
+    )
     .pipe(
       autoprefixer({
         cascade: false,


### PR DESCRIPTION
Just a proposal: Include `node_modules` in Sass `include_path` to make it more comfortable to import Sass partials from node_modules and prevent errors if the imported Sass files refer to other partials (like @material does). 

```
@import '@material/select/mdc-select';
// instead of 
@import 'node_modules/@material/select/mdc-select';
// which throws an error as the partial refers to `@material/…`
```